### PR TITLE
fix: preserve multiple spaces

### DIFF
--- a/lib-x
+++ b/lib-x
@@ -267,13 +267,13 @@ if ! [ -z {} ] && ! [ {} = \"Exit\" ] && ! [ {} = \"Main Menu\" ];then
     CALIBRE_DATA=\"\$(calibredb list --for-machine --fields all)\";
   fi
   title=\"\$(echo {} | sed 's/\\\/\\\\\\\/g;')\";
-  book=\$(echo \$CALIBRE_DATA |jq -r \"map(select(.title == \\\"\$title\\\")) | .[0]\")
-  book_title=\$(echo  \$book|jq -r '.title');
-  book_authors=\$(echo  \$book|jq -r '.authors');
-  book_tags=\$(echo  \$book|jq -r '.tags|join(\", \")');
-  book_cover=\$(echo  \$book|jq -r '.cover');
-  book_comments=\$(echo  \$book|jq -r '.comments');
-  book_langs=\$(echo  \$book|jq -r '.languages[]');
+  book=\$(echo \"\$CALIBRE_DATA\" |jq -r \"map(select(.title == \\\"\$title\\\")) | .[0]\")
+  book_title=\$(echo  \"\$book\"|jq -r '.title');
+  book_authors=\$(echo  \"\$book\"|jq -r '.authors');
+  book_tags=\$(echo  \"\$book\"|jq -r '.tags|join(\", \")');
+  book_cover=\$(echo  \"\$book\"|jq -r '.cover');
+  book_comments=\$(echo  \"\$book\"|jq -r '.comments');
+  book_langs=\$(echo  \"\$book\"|jq -r '.languages[]');
   
   init_pretty_print;
   fzf-preview  \"\$book_cover\";


### PR DESCRIPTION
Sometimes, a file path has multiple spaces.
Without double quotes, the preview would fail.
```diff
< Mou Sha Yong Zhe De Xin Niang  Di Yi Juan  Xie Bo Zhong De Ying Xiong (22200)
---
> Mou Sha Yong Zhe De Xin Niang Di Yi Juan Xie Bo Zhong De Ying Xiong (22200)
```